### PR TITLE
Rename all instances of pterodactyl to pelican

### DIFF
--- a/Api/Admin.php
+++ b/Api/Admin.php
@@ -9,12 +9,12 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
 
-namespace Box\Mod\Servicepterodactyl\Api;
+namespace Box\Mod\Servicepelican\Api;
 
 class Admin extends \Api_Abstract
 {
     /**
-     * Update a Pterodactyl server. Can be used to change the config.
+     * Update a Pelican server. Can be used to change the config.
      *
      * @param array $data - An associative array
      *                    - int 'order_id' (required) The order ID of the server to update.
@@ -26,7 +26,7 @@ class Admin extends \Api_Abstract
     }
 
     /**
-     * Provision a new Pterodactyl server.
+     * Provision a new Pelican server.
      *
      * @param array $data - An associative array
      *                    - int 'order_id' (required) The order ID to provision.
@@ -45,7 +45,7 @@ class Admin extends \Api_Abstract
     }
 
     /**
-     * Unprovision a Pterodactyl server.
+     * Unprovision a Pelican server.
      *
      * @param array $data - An associative array
      *                    - int 'order_id' (required) The order ID to unprovision.
@@ -65,7 +65,7 @@ class Admin extends \Api_Abstract
     }
 
     /**
-     * Suspend a Pterodactyl server.
+     * Suspend a Pelican server.
      *
      * @param array $data - An associative array
      *                    - int 'order_id' (required) The order ID to suspend.
@@ -84,7 +84,7 @@ class Admin extends \Api_Abstract
     }
 
     /**
-     * Unsuspend a Pterodactyl server.
+     * Unsuspend a Pelican server.
      *
      * @param array $data - An associative array
      *                    - int 'order_id' (required) The order ID to unsuspend.
@@ -103,7 +103,7 @@ class Admin extends \Api_Abstract
     }
 
     /**
-     * Change account password on Pterodactyl server.
+     * Change account password on Pelican server.
      * This method is called by FOSSBilling admin interface
      *
      * @param array $data - An associative array
@@ -128,23 +128,23 @@ class Admin extends \Api_Abstract
     }
 
     /**
-     * Save global Pterodactyl settings.
+     * Save global Pelican settings.
      *
      * @param array $data - An associative array with settings
      */
     public function save_settings($data): bool
     {
         $systemService = $this->di['mod_service']('system');
-        
+
         $settings = [
-            'servicepterodactyl_panel_url' => $data['panel_url'] ?? '',
-            'servicepterodactyl_api_key' => $data['api_key'] ?? '',
-            'servicepterodactyl_default_node' => $data['default_node'] ?? 1,
-            'servicepterodactyl_default_egg' => $data['default_egg'] ?? 1,
-            'servicepterodactyl_default_docker_image' => $data['default_docker_image'] ?? 'quay.io/pterodactyl/core:java',
-            'servicepterodactyl_default_memory' => $data['default_memory'] ?? 512,
-            'servicepterodactyl_default_disk' => $data['default_disk'] ?? 1024,
-            'servicepterodactyl_default_cpu' => $data['default_cpu'] ?? 100,
+            'servicepelican_panel_url' => $data['panel_url'] ?? '',
+            'servicepelican_api_key' => $data['api_key'] ?? '',
+            'servicepelican_default_node' => $data['default_node'] ?? 1,
+            'servicepelican_default_egg' => $data['default_egg'] ?? 1,
+            'servicepelican_default_docker_image' => $data['default_docker_image'] ?? 'quay.io/pelican/core:java',
+            'servicepelican_default_memory' => $data['default_memory'] ?? 512,
+            'servicepelican_default_disk' => $data['default_disk'] ?? 1024,
+            'servicepelican_default_cpu' => $data['default_cpu'] ?? 100,
         ];
         
         foreach ($settings as $key => $value) {

--- a/Api/Client.php
+++ b/Api/Client.php
@@ -9,7 +9,7 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
 
-namespace Box\Mod\Servicepterodactyl\Api;
+namespace Box\Mod\Servicepelican\Api;
 
 class Client extends \Api_Abstract
 {
@@ -41,7 +41,7 @@ class Client extends \Api_Abstract
         return $service->toApiArray($model);
     }
     /**
-     * Restart a Pterodactyl server
+     * Restart a Pelican server
      *
      * @param array $data - An associative array
      *                    - int 'order_id' The order ID of the server to restart.
@@ -56,7 +56,7 @@ class Client extends \Api_Abstract
     }
 
     /**
-     * Change password for Pterodactyl user
+     * Change password for Pelican user
      *
      * @param array $data - An associative array
      *                    - int 'order_id' The order ID of the server

--- a/Api/Guest.php
+++ b/Api/Guest.php
@@ -9,7 +9,7 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
 
-namespace Box\Mod\Servicepterodactyl\Api;
+namespace Box\Mod\Servicepelican\Api;
 
 class Guest extends \Api_Abstract
 {

--- a/Controller/Admin.php
+++ b/Controller/Admin.php
@@ -9,7 +9,7 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
 
-namespace Box\Mod\Servicepterodactyl\Controller;
+namespace Box\Mod\Servicepelican\Controller;
 
 class Admin implements \FOSSBilling\InjectionAwareInterface
 {
@@ -29,10 +29,10 @@ class Admin implements \FOSSBilling\InjectionAwareInterface
     {
         $hooks->on(
             'system.admin.controller',
-            'get:/servicepterodactyl/settings',
+            'get:/servicepelican/settings',
             [$this, 'get_settings'],
             [],
-            'servicepterodactyl'
+            'servicepelican'
         );
     }
 
@@ -43,16 +43,16 @@ class Admin implements \FOSSBilling\InjectionAwareInterface
         // Get current settings
         $systemService = $this->di['mod_service']('system');
         $settings = [
-            'panel_url' => $systemService->getParamValue('servicepterodactyl_panel_url', ''),
-            'api_key' => $systemService->getParamValue('servicepterodactyl_api_key', ''),
-            'default_node' => $systemService->getParamValue('servicepterodactyl_default_node', 1),
-            'default_egg' => $systemService->getParamValue('servicepterodactyl_default_egg', 1),
-            'default_docker_image' => $systemService->getParamValue('servicepterodactyl_default_docker_image', 'quay.io/pterodactyl/core:java'),
-            'default_memory' => $systemService->getParamValue('servicepterodactyl_default_memory', 512),
-            'default_disk' => $systemService->getParamValue('servicepterodactyl_default_disk', 1024),
-            'default_cpu' => $systemService->getParamValue('servicepterodactyl_default_cpu', 100),
+            'panel_url' => $systemService->getParamValue('servicepelican_panel_url', ''),
+            'api_key' => $systemService->getParamValue('servicepelican_api_key', ''),
+            'default_node' => $systemService->getParamValue('servicepelican_default_node', 1),
+            'default_egg' => $systemService->getParamValue('servicepelican_default_egg', 1),
+            'default_docker_image' => $systemService->getParamValue('servicepelican_default_docker_image', 'quay.io/pelican/core:java'),
+            'default_memory' => $systemService->getParamValue('servicepelican_default_memory', 512),
+            'default_disk' => $systemService->getParamValue('servicepelican_default_disk', 1024),
+            'default_cpu' => $systemService->getParamValue('servicepelican_default_cpu', 100),
         ];
-        
-        return $view->render('mod_servicepterodactyl_settings', ['settings' => $settings]);
+
+        return $view->render('mod_servicepelican_settings', ['settings' => $settings]);
     }
 }

--- a/Controller/Client.php
+++ b/Controller/Client.php
@@ -9,7 +9,7 @@
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache-2.0
  */
 
-namespace Box\Mod\Servicepterodactyl\Controller;
+namespace Box\Mod\Servicepelican\Controller;
 
 class Admin implements \FOSSBilling\InjectionAwareInterface
 {
@@ -29,10 +29,10 @@ class Admin implements \FOSSBilling\InjectionAwareInterface
     {
         $hooks->on(
             'system.client.controller',
-            'get:/servicepterodactyl/:id',
+            'get:/servicepelican/:id',
             [$this, 'get_manage'],
             ['id' => '[0-9]+'],
-            'servicepterodactyl'
+            'servicepelican'
         );
     }
 
@@ -40,13 +40,13 @@ class Admin implements \FOSSBilling\InjectionAwareInterface
     {
         $api = $this->di['api']('client');
         $data = $api->order_get(['id' => $id]);
-        if ($data['service_type'] !== 'servicepterodactyl') {
+        if ($data['service_type'] !== 'servicepelican') {
             throw new \FOSSBilling\Exception('Invalid order type');
         }
 
-        $service = $api->servicepterodactyl_get(['order_id' => $id]);
-        
-        return $view->render('mod_servicepterodactyl_manage', [
+        $service = $api->servicepelican_get(['order_id' => $id]);
+
+        return $view->render('mod_servicepelican_manage', [
             'order' => $data,
             'service' => $service
         ]);

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A free and open-source module that connects **Pelican** with **FOSSBilling**, al
 
 * ✅ **Automatic Server Provisioning** – Deploy servers instantly after payment confirmation.
 * ✅ **Suspend / Unsuspend Servers** – Automatic suspension for overdue invoices and instant reactivation on payment.
-* ✅ **Multiple Node Support** – Assign products to specific Pterodactyl nodes.
+* ✅ **Multiple Node Support** – Assign products to specific Pelican nodes.
 * ✅ **Custom Resource Allocation** – Configure CPU, RAM, disk, and other limits per product plan.
 * ✅ **Client Panel Access** – Clients can see their server details directly in FOSSBilling.
 
@@ -31,7 +31,7 @@ A free and open-source module that connects **Pelican** with **FOSSBilling**, al
 2. **Upload the module** to your FOSSBilling `/modules/` directory.
 3. **Activate the module** from the FOSSBilling admin panel.
 4. **Configure your Pelican credentials** (API URL and keys) in the module settings.
-5. **Create products** in FOSSBilling linked to your Pterodactyl servers and plans.
+5. **Create products** in FOSSBilling linked to your Pelican servers and plans.
 
 ## 🛠 Roadmap
 

--- a/Service.php
+++ b/Service.php
@@ -69,7 +69,7 @@ class Service implements InjectionAwareInterface
             if (!$client) {
                 throw new \FOSSBilling\Exception('Client not found');
             }
-            $serverData = $this->createPterodactylServer($config, $client);
+            $serverData = $this->createPelicanServer($config, $client);
             
             $model->server_id = $serverData['id'];
             $model->server_identifier = $serverData['identifier'];
@@ -149,7 +149,7 @@ class Service implements InjectionAwareInterface
                 }
                 $this->panelConfig = $this->getPanelConfig($config);
                 
-                // Delete server from Pterodactyl if exists
+                // Delete server from Pelican if exists
                 if ($model->server_id) {
                     $this->deletePelicanServer($model->server_id);
                 }
@@ -193,7 +193,7 @@ class Service implements InjectionAwareInterface
 
 
     /**
-     * Creates the database structure to store the Pterodactyl server information.
+     * Creates the database structure to store the Pelican server information.
      */
     public function install(): bool
     {
@@ -215,7 +215,7 @@ class Service implements InjectionAwareInterface
     }
 
     /**
-     * Removes the Pterodactyl service table from the database.
+     * Removes the Pelican service table from the database.
      */
     public function uninstall(): bool
     {
@@ -225,7 +225,7 @@ class Service implements InjectionAwareInterface
     }
 
     /**
-     * Creates a new server on Pterodactyl panel
+     * Creates a new server on Pelican panel
      */
     private function createPelicanServer(array $config, OODBBean $client): array
     {
@@ -282,7 +282,7 @@ class Service implements InjectionAwareInterface
     }
 
     /**
-     * Suspend a server on Pterodactyl panel
+     * Suspend a server on Pelican panel
      */
     private function suspendPelicanServer(int $serverId): void
     {
@@ -290,7 +290,7 @@ class Service implements InjectionAwareInterface
     }
 
     /**
-     * Unsuspend a server on Pterodactyl panel
+     * Unsuspend a server on Pelican panel
      */
     private function unsuspendPelicanServer(int $serverId): void
     {
@@ -298,7 +298,7 @@ class Service implements InjectionAwareInterface
     }
 
     /**
-     * Delete a server on Pterodactyl panel
+     * Delete a server on Pelican panel
      */
     private function deletePelicanServer(int $serverId): void
     {
@@ -306,7 +306,7 @@ class Service implements InjectionAwareInterface
     }
 
     /**
-     * Get or create a user on Pterodactyl panel
+     * Get or create a user on Pelican panel
      */
     private function getOrCreateUser(string $email, OODBBean $client): int
     {
@@ -435,7 +435,7 @@ class Service implements InjectionAwareInterface
     }
 
     /**
-     * Get egg information from Pterodactyl
+     * Get egg information from Pelican
      */
     private function getEggInfo(int $eggId): array
     {
@@ -517,7 +517,7 @@ class Service implements InjectionAwareInterface
     }
 
     /**
-     * Restart a server on Pterodactyl panel
+     * Restart a server on Pelican panel
      */
     public function restartServer(int $orderId): bool
     {
@@ -600,7 +600,7 @@ class Service implements InjectionAwareInterface
                 throw new \FOSSBilling\Exception('Client not found');
             }
             
-            // Get user ID from Pterodactyl
+            // Get user ID from Pelican
             $userEmail = $client->email ?? 'noemail@example.com';
             $userId = $this->getOrCreateUser($userEmail, $client);
             

--- a/html_admin/mod_servicepterodactyl_config.html.twig
+++ b/html_admin/mod_servicepterodactyl_config.html.twig
@@ -1,7 +1,7 @@
 {% import 'macro_functions.html.twig' as mf %}
     <div class="card-body">
-        <h1>{{ 'Pterodactyl Panel Configuration'|trans }}</h1>
-        <form method="post" action="{{ 'api/admin/product/update_config'|link }}" class="api-form save" data-api-msg="{{ 'Pterodactyl settings updated'|trans }}">
+        <h1>{{ 'Pelican Panel Configuration'|trans }}</h1>
+        <form method="post" action="{{ 'api/admin/product/update_config'|link }}" class="api-form save" data-api-msg="{{ 'Pelican settings updated'|trans }}">
             <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
             
             <h2>{{ 'Default Server Settings'|trans }}</h2>

--- a/html_admin/mod_servicepterodactyl_manage.html.twig
+++ b/html_admin/mod_servicepterodactyl_manage.html.twig
@@ -39,7 +39,7 @@
     {{ order_actions }}
     
     <a class="btn btn-success api-link"
-        href="{{ 'api/admin/servicepterodactyl/provision'|link({ 'order_id': order.id, 'CSRFToken': CSRFToken }) }}"
+        href="{{ 'api/admin/servicepelican/provision'|link({ 'order_id': order.id, 'CSRFToken': CSRFToken }) }}"
         data-api-confirm="{{ 'Are you sure you want to provision this service?'|trans }}"
         data-api-reload="1">
         <svg class="icon" width="24" height="24">
@@ -49,7 +49,7 @@
     </a>
     
     <a class="btn btn-warning api-link"
-        href="{{ 'api/admin/servicepterodactyl/suspend'|link({ 'order_id': order.id, 'CSRFToken': CSRFToken }) }}"
+        href="{{ 'api/admin/servicepelican/suspend'|link({ 'order_id': order.id, 'CSRFToken': CSRFToken }) }}"
         data-api-confirm="{{ 'Are you sure you want to suspend this service?'|trans }}"
         data-api-reload="1">
         <svg class="icon" width="24" height="24">
@@ -59,7 +59,7 @@
     </a>
     
     <a class="btn btn-danger api-link"
-        href="{{ 'api/admin/servicepterodactyl/unprovision'|link({ 'order_id': order.id, 'CSRFToken': CSRFToken }) }}"
+        href="{{ 'api/admin/servicepelican/unprovision'|link({ 'order_id': order.id, 'CSRFToken': CSRFToken }) }}"
         data-api-confirm="{{ 'Are you sure you want to unprovision this service?'|trans }}"
         data-api-reload="1">
         <svg class="icon" width="24" height="24">
@@ -69,7 +69,7 @@
     </a>
     
     <a class="btn btn-primary api-link"
-        href="{{ 'api/admin/servicepterodactyl/reset'|link({ 'order_id': order.id, 'CSRFToken': CSRFToken }) }}"
+        href="{{ 'api/admin/servicepelican/reset'|link({ 'order_id': order.id, 'CSRFToken': CSRFToken }) }}"
         data-api-confirm="{{ 'Are you sure?'|trans }}"
         data-api-reload="1">
         <svg class="icon" width="24" height="24">
@@ -83,7 +83,7 @@
     <h2>{{ 'Server configuration'|trans }}</h2>
     <P>{{ 'Changing the server configuration will not automatically update the existing server. You must recreate it manually.'|trans }}</p>
 
-    <form action="{{ 'api/admin/servicepterodactyl/update'|link }}" method="post" class="api-form" data-api-msg="{{ 'API key updated'|trans }}">
+    <form action="{{ 'api/admin/servicepelican/update'|link }}" method="post" class="api-form" data-api-msg="{{ 'API key updated'|trans }}">
         <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
         <div class="mb-3 row">
             <label class="form-label col-3 col-form-label">{{ 'Length'|trans }}:</label>

--- a/html_admin/mod_servicepterodactyl_settings.html.twig
+++ b/html_admin/mod_servicepterodactyl_settings.html.twig
@@ -2,7 +2,7 @@
 {% import "macro_functions.html.twig" as mf %}
 
 {% block meta_title %}
-    {{ 'Pterodactyl Global Settings'|trans }}
+    {{ 'Pelican Global Settings'|trans }}
 {% endblock %}
 
 {% set active_menu = 'system' %}
@@ -22,7 +22,7 @@
             </a>
         </li>
         <li class="breadcrumb-item active" aria-current="page">
-            {{ 'Pterodactyl Global Settings'|trans }}
+            {{ 'Pelican Global Settings'|trans }}
         </li>
     </ul>
 {% endblock %}
@@ -38,7 +38,7 @@
         <div class="card">
             <div class="tab-content">
                 <div class="tab-pane fade show active" id="tab-general" role="tabpanel">
-                    <form method="post" action="{{ 'api/admin/servicepterodactyl/save_settings'|link }}" class="api-form save" data-api-msg="{{ 'Settings saved successfully'|trans }}">
+                    <form method="post" action="{{ 'api/admin/servicepelican/save_settings'|link }}" class="api-form save" data-api-msg="{{ 'Settings saved successfully'|trans }}">
                         <input type="hidden" name="CSRFToken" value="{{ CSRFToken }}"/>
                         
                         <div class="card-body">
@@ -47,7 +47,7 @@
                                 <label class="form-label col-3 col-form-label">{{ 'Panel URL'|trans }}:</label>
                                 <div class="col">
                                     <input type="url" class="form-control" name="panel_url" value="{{ settings.panel_url|default('') }}" placeholder="https://panel.example.com">
-                                    <div class="form-text">{{ 'The URL of your Pterodactyl panel'|trans }}</div>
+                                    <div class="form-text">{{ 'The URL of your Pelican panel'|trans }}</div>
                                 </div>
                             </div>
                             
@@ -55,7 +55,7 @@
                                 <label class="form-label col-3 col-form-label">{{ 'API Key'|trans }}:</label>
                                 <div class="col">
                                     <input type="password" class="form-control" name="api_key" value="{{ settings.api_key|default('') }}" placeholder="ptla_...">
-                                    <div class="form-text">{{ 'Application API key from Pterodactyl panel'|trans }}</div>
+                                    <div class="form-text">{{ 'Application API key from Pelican panel'|trans }}</div>
                                 </div>
                             </div>
 

--- a/html_client/mod_servicepterodactyl_manage.html.twig
+++ b/html_client/mod_servicepterodactyl_manage.html.twig
@@ -4,7 +4,7 @@
         <h2>{{ order.title }}</h2>
     </div>
     <div class="card-body">
-        <h3>{{ 'Détails du serveur Pterodactyl'|trans }}</h3>
+        <h3>{{ 'Détails du serveur Pelican'|trans }}</h3>
         <table class="table table-striped table-bordered table-sm">
             <tbody>
                 <tr>
@@ -56,7 +56,7 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="changePasswordModalLabel">{{ 'Change Pterodactyl Password'|trans }}</h5>
+                <h5 class="modal-title" id="changePasswordModalLabel">{{ 'Change Pelican Password'|trans }}</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="{{ 'Close'|trans }}"></button>
             </div>
             <form id="changePasswordForm">
@@ -96,7 +96,7 @@ $('#changePasswordForm').submit(function(e) {
     btn.prop('disabled', true);
     btn.html('<span class="spinner-border spinner-border-sm me-2"></span>{{ 'Processing...'|trans }}');
     
-    $.post('{{ 'api/client/servicepterodactyl/change_password'|link }}', {
+    $.post('{{ 'api/client/servicepelican/change_password'|link }}', {
         order_id: {{ order.id }},
         new_password: newPassword,
         confirm_password: confirmPassword,


### PR DESCRIPTION
- Updated all namespaces from Servicepterodactyl to Servicepelican
- Changed all API routes from servicepterodactyl to servicepelican
- Updated all comments and documentation references
- Changed all settings keys from servicepterodactyl_* to servicepelican_*
- Updated Docker image URL from pterodactyl to pelican
- Modified template file references to use pelican naming
- Updated README.md to reference Pelican instead of Pterodactyl