### PR TITLE
Fix user creation API to use correct Pelican API format

### DIFF
--- a/Service.php
+++ b/Service.php
@@ -313,28 +313,29 @@ class Service implements InjectionAwareInterface
         try {
             // First try to find existing user
             $response = $this->pelicanApiRequest('GET', "/api/application/users?filter[email]={$email}");
-            
+
             if (!empty($response['data'])) {
                 return $response['data'][0]['attributes']['id'];
             }
-            
+
             // Create new user if not found
             $userData = [
                 'email' => $email,
+                'external_id' => (string)$client->id,
                 'username' => $this->generateUsername($email),
-                'first_name' => $client->first_name ?? 'Client',
-                'last_name' => $client->last_name ?? 'User',
                 'password' => $this->generateRandomPassword(),
+                'language' => 'en',
+                'timezone' => 'UTC',
             ];
-            
+
             $response = $this->pelicanApiRequest('POST', '/api/application/users', $userData);
-            
+
             if (!isset($response['attributes']['id'])) {
                 throw new \FOSSBilling\Exception('Failed to create user on Pelican');
             }
-            
+
             return $response['attributes']['id'];
-            
+
         } catch (\Exception $e) {
             throw new \FOSSBilling\Exception('Failed to get or create user: ' . $e->getMessage());
         }
@@ -594,12 +595,13 @@ class Service implements InjectionAwareInterface
             // Update password via Pelican API
             $userData = [
                 'email' => $userEmail,
+                'external_id' => (string)$client->id,
                 'username' => $this->generateUsername($userEmail),
-                'first_name' => $client->first_name ?? 'Client',
-                'last_name' => $client->last_name ?? 'User',
                 'password' => $newPassword,
+                'language' => 'en',
+                'timezone' => 'UTC',
             ];
-            
+
             $this->pelicanApiRequest('PATCH', "/api/application/users/{$userId}", $userData);
             
             // Log the password change


### PR DESCRIPTION
Updated getOrCreateUser() and changeAccountPassword() to send the correct body format to Pelican API endpoint /api/application/users:
- Added external_id field (using client ID)
- Added language field (default: 'en')
- Added timezone field (default: 'UTC')
- Removed first_name and last_name fields

This aligns with Pelican's API specification for user creation.