### PR TITLE
Fix type error in Controller register() methods

### DIFF
--- a/Controller/Admin.php
+++ b/Controller/Admin.php
@@ -25,7 +25,7 @@ class Admin implements \FOSSBilling\InjectionAwareInterface
         return $this->di;
     }
 
-    public function register(\FOSSBilling\Events $hooks): void
+    public function register(\Box_AppAdmin $hooks): void
     {
         $hooks->on(
             'system.admin.controller',

--- a/Controller/Client.php
+++ b/Controller/Client.php
@@ -11,7 +11,7 @@
 
 namespace Box\Mod\Servicepelican\Controller;
 
-class Admin implements \FOSSBilling\InjectionAwareInterface
+class Client implements \FOSSBilling\InjectionAwareInterface
 {
     protected $di;
 
@@ -24,8 +24,8 @@ class Admin implements \FOSSBilling\InjectionAwareInterface
     {
         return $this->di;
     }
-    
-    public function register(\FOSSBilling\Events $hooks): void
+
+    public function register(\Box_AppClient $hooks): void
     {
         $hooks->on(
             'system.client.controller',


### PR DESCRIPTION
- Changed Admin::register() parameter type from FOSSBilling\Events to Box_AppAdmin
- Changed Client::register() parameter type from FOSSBilling\Events to Box_AppClient
- Fixed Client controller class name (was incorrectly named Admin)

Resolves the error: "Argument #1 ($hooks) must be of type FOSSBilling\Events, Box_AppAdmin given"